### PR TITLE
README.md get_edits and get_highlight example small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ for influent_sentence in influent_sentences:
     corrected_sentences = gf.correct(influent_sentence, max_candidates=1)
     print("[Input] ", influent_sentence)
     for corrected_sentence in corrected_sentences:
-      print("[Edits] ", gf.get_edits(influent_sentence, corrected_sentence[0]))
+      print("[Edits] ", gf.get_edits(influent_sentence, corrected_sentence))
     print("-" *100)
 ```
 
@@ -221,7 +221,7 @@ for influent_sentence in influent_sentences:
     corrected_sentences = gf.correct(influent_sentence, max_candidates=1)
     print("[Input] ", influent_sentence)
     for corrected_sentence in corrected_sentences:
-      print("[Edits] ", gf.highlight(influent_sentence, corrected_sentence[0]))
+      print("[Edits] ", gf.highlight(influent_sentence, corrected_sentence))
     print("-" *100)
 ```
 


### PR DESCRIPTION
Hi there, when I copy and pasted the examples in the README locally I noticed they were bugging out for the edits and highlights (were only pulling the first char of the sentence for errant). Providing the full sentence seemed to get the desired output. 