### PR TITLE
Spacy 3

### DIFF
--- a/gramformer/gramformer.py
+++ b/gramformer/gramformer.py
@@ -6,8 +6,11 @@ class Gramformer:
     #from lm_scorer.models.auto import AutoLMScorer as LMScorer
     import errant
     import spacy
-    
-    nlp = spacy.load(model, disable=["ner"])
+
+    nlp = None
+    if model is not None:
+        nlp = spacy.load(model, disable=["ner"])
+          
     self.annotator = errant.load('en', nlp=nlp)
     
     if use_gpu:

--- a/gramformer/gramformer.py
+++ b/gramformer/gramformer.py
@@ -1,11 +1,14 @@
 class Gramformer:
 
-  def __init__(self, models=1, use_gpu=False):
+  def __init__(self, models=1, use_gpu=False, model=None):
     from transformers import AutoTokenizer
     from transformers import AutoModelForSeq2SeqLM
     #from lm_scorer.models.auto import AutoLMScorer as LMScorer
     import errant
-    self.annotator = errant.load('en')
+    import spacy
+    
+    nlp = spacy.load(model, disable=["ner"])
+    self.annotator = errant.load('en', nlp=nlp)
     
     if use_gpu:
         device= "cuda:0"


### PR DESCRIPTION
When using en-core-web-sm there is a problem with the naming of models. Spacy does not support abbreviations of models, now they require full names to load them. That is why I added an optional model parameter to the main class. Also added the calling of model from spacy.